### PR TITLE
FLOW-2126: Ensure auth token is passed in callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+dependency-reduced-pom.xml
 
 
 ### Intellij ###
@@ -50,3 +51,10 @@ com_crashlytics_export_strings.xml
 
 # Generated properties
 *.properties
+
+### VSCode ###
+.vscode/
+.classpath
+.project
+.settings
+.factorypath

--- a/src/main/java/com/manywho/services/twilio/configuration/TwilioConfiguration.java
+++ b/src/main/java/com/manywho/services/twilio/configuration/TwilioConfiguration.java
@@ -26,7 +26,7 @@ public class TwilioConfiguration {
     }
 
     public String getSmsStatusCallback() {
-        return "http://04d618b2f04a.ngrok.io/" + "callback/status/message";
+        return uriInfo.getBaseUri().toString() + "callback/status/message";
     }
 
     public String getVoiceUrl() {

--- a/src/main/java/com/manywho/services/twilio/configuration/TwilioConfiguration.java
+++ b/src/main/java/com/manywho/services/twilio/configuration/TwilioConfiguration.java
@@ -26,7 +26,7 @@ public class TwilioConfiguration {
     }
 
     public String getSmsStatusCallback() {
-        return uriInfo.getBaseUri().toString() + "callback/status/message";
+        return "http://04d618b2f04a.ngrok.io/" + "callback/status/message";
     }
 
     public String getVoiceUrl() {

--- a/src/main/java/com/manywho/services/twilio/controllers/MessageController.java
+++ b/src/main/java/com/manywho/services/twilio/controllers/MessageController.java
@@ -49,6 +49,7 @@ public class MessageController extends AbstractController {
         ObjectCollection replyObject = messageManager.sendMms(
                 serviceRequest,
                 configuration,
+                getAuthenticatedWho(),
                 mms.getMessage().getTo(),
                 mms.getMessage().getFrom(),
                 mms.getMessage().getBody(),
@@ -80,6 +81,7 @@ public class MessageController extends AbstractController {
             replyObject = messageManager.sendSms(
                     serviceRequest,
                     configuration,
+                    getAuthenticatedWho(),
                     smsRequest.getMessage().getTo(),
                     smsRequest.getMessage().getFrom(),
                     smsRequest.getMessage().getBody()
@@ -97,7 +99,7 @@ public class MessageController extends AbstractController {
 
         return serviceResponse;
     }
-
+    
     @Path("/smssimple")
     @POST
     @AuthorizationRequired
@@ -113,6 +115,7 @@ public class MessageController extends AbstractController {
             messageManager.sendSms(
                     serviceRequest,
                     configuration,
+                    getAuthenticatedWho(),
                     smsRequest.getTo(),
                     smsRequest.getFrom(),
                     smsRequest.getBody()

--- a/src/main/java/com/manywho/services/twilio/managers/CallbackManager.java
+++ b/src/main/java/com/manywho/services/twilio/managers/CallbackManager.java
@@ -3,6 +3,7 @@ package com.manywho.services.twilio.managers;
 import com.manywho.sdk.client.FlowClient;
 import com.manywho.sdk.client.entities.FlowState;
 import com.manywho.sdk.entities.run.elements.config.ServiceRequest;
+import com.manywho.sdk.entities.security.AuthenticatedWho;
 import com.manywho.sdk.enums.InvokeType;
 import com.manywho.services.twilio.entities.MessageCallback;
 import com.manywho.services.twilio.services.CallbackMessageService;
@@ -43,14 +44,15 @@ public class CallbackManager {
         }
 
         ServiceRequest request = cacheManager.getMessageRequest(accountSid, messageSid);
+        AuthenticatedWho authenticatedWho = cacheManager.getAuthenticatedWho(accountSid, messageSid);
 
         // Send the callback back to ManyWho, with any WAIT messages or error messages
-        InvokeType response = callbackMessageService.sendMessageResponse(request, errorMessage, errorMessage);
+        InvokeType response = callbackMessageService.sendMessageResponse(request, authenticatedWho, errorMessage, errorMessage);
 
         // If the message has been sent, and the Engine is waiting, assume we're waiting for a reply
         if (messageStatus.equalsIgnoreCase("sent") && response.equals(InvokeType.Wait)) {
             cacheManager.stateWaitingForSms(callback.getFrom() + callback.getTo(), request.getStateId());
-            callbackMessageService.sendMessageResponse(request, "Waiting for a reply to the SMS", null);
+            callbackMessageService.sendMessageResponse(request, authenticatedWho, "Waiting for a reply to the SMS", null);
 
             FlowState flowState = flowClient.join(UUID.fromString(request.getTenantId()), UUID.fromString(request.getStateId()), null);
             if(!flowState.getInvokeType().equals(InvokeType.Wait)) {

--- a/src/main/java/com/manywho/services/twilio/managers/CallbackManager.java
+++ b/src/main/java/com/manywho/services/twilio/managers/CallbackManager.java
@@ -67,8 +67,9 @@ public class CallbackManager {
 
     public void processMessageReply(String accountSid, String messageSid, String from, String to, String body) throws Exception {
         ServiceRequest request = cacheManager.getMessageRequest(accountSid, to + from);
+        AuthenticatedWho authenticatedWho = cacheManager.getAuthenticatedWho(accountSid, to + from);
 
-        callbackMessageService.sendMessageReplyResponse(request, messageSid, from, to, body);
+        callbackMessageService.sendMessageReplyResponse(request, authenticatedWho, messageSid, from, to, body);
     }
 
     public void sendCallResponse(String callSid, String answeredBy) throws Exception {

--- a/src/main/java/com/manywho/services/twilio/managers/MessageManager.java
+++ b/src/main/java/com/manywho/services/twilio/managers/MessageManager.java
@@ -30,7 +30,7 @@ public class MessageManager {
         messageService.storeMessageRequest(mms.getAccountSid(), mms.getSid(), mms.getFrom(), mms.getTo(), serviceRequest);
 
         // Store the authenticatedWho for the request in Redis for any callbacks later
-        messageService.storeAuthenticatedWho(mms.getAccountSid(), mms.getSid(), authenticatedWho);
+        messageService.storeAuthenticatedWho(mms.getAccountSid(), mms.getSid(), mms.getFrom(), mms.getTo(), authenticatedWho);
 
         return new ObjectCollection(objectMapperService.convertMmsToObject(new Mms(
                 mms.getSid(),
@@ -49,7 +49,7 @@ public class MessageManager {
         messageService.storeMessageRequest(sms.getAccountSid(), sms.getSid(), sms.getFrom(), sms.getTo(), serviceRequest);
 
         // Store the authenticatedWho for the request in Redis for any callbacks later
-        messageService.storeAuthenticatedWho(sms.getAccountSid(), sms.getSid(), authenticatedWho);
+        messageService.storeAuthenticatedWho(sms.getAccountSid(), sms.getSid(), sms.getFrom(), sms.getTo(), authenticatedWho);
 
         return new ObjectCollection(objectMapperService.convertSmsToObject(new com.manywho.services.twilio.types.Sms(
                 sms.getSid(),

--- a/src/main/java/com/manywho/services/twilio/managers/MessageManager.java
+++ b/src/main/java/com/manywho/services/twilio/managers/MessageManager.java
@@ -2,6 +2,7 @@ package com.manywho.services.twilio.managers;
 
 import com.manywho.sdk.entities.run.elements.config.ServiceRequest;
 import com.manywho.sdk.entities.run.elements.type.ObjectCollection;
+import com.manywho.sdk.entities.security.AuthenticatedWho;
 import com.manywho.services.twilio.entities.Configuration;
 import com.manywho.services.twilio.services.MessageService;
 import com.manywho.services.twilio.services.ObjectMapperService;
@@ -21,12 +22,15 @@ public class MessageManager {
     @Inject
     private ObjectMapperService objectMapperService;
 
-    public ObjectCollection sendMms(ServiceRequest serviceRequest, Configuration configuration, String to, String from, String body, List<Media> media) throws Exception {
+    public ObjectCollection sendMms(ServiceRequest serviceRequest, Configuration configuration, AuthenticatedWho authenticatedWho, String to, String from, String body, List<Media> media) throws Exception {
         // Send the MMS through Twilio
         final Message mms = messageService.sendMms(configuration.getAccountSid(), configuration.getAuthToken(), to, from, body, media);
 
         // Store the message request in Redis for later
         messageService.storeMessageRequest(mms.getAccountSid(), mms.getSid(), mms.getFrom(), mms.getTo(), serviceRequest);
+
+        // Store the authenticatedWho for the request in Redis for any callbacks later
+        messageService.storeAuthenticatedWho(mms.getAccountSid(), mms.getSid(), authenticatedWho);
 
         return new ObjectCollection(objectMapperService.convertMmsToObject(new Mms(
                 mms.getSid(),
@@ -37,12 +41,15 @@ public class MessageManager {
         )));
     }
 
-    public ObjectCollection sendSms(ServiceRequest serviceRequest, Configuration configuration, String to, String from, String body) throws Exception {
+    public ObjectCollection sendSms(ServiceRequest serviceRequest, Configuration configuration, AuthenticatedWho authenticatedWho, String to, String from, String body) throws Exception {
          // Send the SMS through Twilio
         final Message sms = messageService.sendSms(configuration.getAccountSid(), configuration.getAuthToken(), to, from, body);
 
         // Store the message request in Redis for later
         messageService.storeMessageRequest(sms.getAccountSid(), sms.getSid(), sms.getFrom(), sms.getTo(), serviceRequest);
+
+        // Store the authenticatedWho for the request in Redis for any callbacks later
+        messageService.storeAuthenticatedWho(sms.getAccountSid(), sms.getSid(), authenticatedWho);
 
         return new ObjectCollection(objectMapperService.convertSmsToObject(new com.manywho.services.twilio.types.Sms(
                 sms.getSid(),

--- a/src/main/java/com/manywho/services/twilio/services/CallbackMessageService.java
+++ b/src/main/java/com/manywho/services/twilio/services/CallbackMessageService.java
@@ -31,7 +31,7 @@ public class CallbackMessageService {
     private CacheManager cacheManager;
 
     public InvokeType sendMessageResponse(ServiceRequest serviceRequest, AuthenticatedWho authenticatedWho, String waitMessageText, String errorMessageText) throws Exception {
-        ServiceResponse serviceResponse = new ServiceResponse(InvokeType.Wait, serviceRequest.getToken());
+        ServiceResponse serviceResponse = new ServiceResponse(InvokeType.Forward, serviceRequest.getToken());
         serviceResponse.setTenantId(serviceRequest.getTenantId());
 
         if (errorMessageText != null) {
@@ -45,7 +45,7 @@ public class CallbackMessageService {
         return runService.sendResponse(null, authenticatedWho, serviceRequest.getTenantId(), serviceRequest.getCallbackUri(), serviceResponse);
     }
 
-    public void sendMessageReplyResponse(ServiceRequest serviceRequest, String messageSid, String from, String to, String body) throws Exception {
+    public void sendMessageReplyResponse(ServiceRequest serviceRequest, AuthenticatedWho authenticatedWho, String messageSid, String from, String to, String body) throws Exception {
         EngineValueCollection replyOutput = new EngineValueCollection();
 
         LOGGER.debug("Processing reply from {} to {}", from, to);
@@ -61,7 +61,7 @@ public class CallbackMessageService {
         ServiceResponse serviceResponse = new ServiceResponse(InvokeType.Forward, replyOutput, serviceRequest.getToken());
         serviceResponse.setTenantId(serviceRequest.getTenantId());
 
-        InvokeType invokeType = runService.sendResponse(null, null, serviceRequest.getTenantId(), serviceRequest.getCallbackUri(), serviceResponse);
+        InvokeType invokeType = runService.sendResponse(null, authenticatedWho, serviceRequest.getTenantId(), serviceRequest.getCallbackUri(), serviceResponse);
         LOGGER.debug("Send response to engine {}", invokeType);
     }
 }

--- a/src/main/java/com/manywho/services/twilio/services/CallbackMessageService.java
+++ b/src/main/java/com/manywho/services/twilio/services/CallbackMessageService.java
@@ -6,8 +6,10 @@ import com.manywho.sdk.entities.run.EngineValueCollection;
 import com.manywho.sdk.entities.run.elements.config.ServiceRequest;
 import com.manywho.sdk.entities.run.elements.config.ServiceResponse;
 import com.manywho.sdk.entities.run.elements.type.MObject;
+import com.manywho.sdk.entities.security.AuthenticatedWho;
 import com.manywho.sdk.enums.ContentType;
 import com.manywho.sdk.enums.InvokeType;
+import com.manywho.sdk.services.providers.ObjectMapperProvider;
 import com.manywho.services.twilio.managers.CacheManager;
 import com.manywho.services.twilio.types.Sms;
 import org.apache.logging.log4j.LogManager;
@@ -28,8 +30,8 @@ public class CallbackMessageService {
     @Inject
     private CacheManager cacheManager;
 
-    public InvokeType sendMessageResponse(ServiceRequest serviceRequest, String waitMessageText, String errorMessageText) throws Exception {
-        ServiceResponse serviceResponse = new ServiceResponse(InvokeType.Forward, serviceRequest.getToken());
+    public InvokeType sendMessageResponse(ServiceRequest serviceRequest, AuthenticatedWho authenticatedWho, String waitMessageText, String errorMessageText) throws Exception {
+        ServiceResponse serviceResponse = new ServiceResponse(InvokeType.Wait, serviceRequest.getToken());
         serviceResponse.setTenantId(serviceRequest.getTenantId());
 
         if (errorMessageText != null) {
@@ -39,8 +41,8 @@ public class CallbackMessageService {
         if (waitMessageText != null) {
             serviceResponse.setWaitMessage(waitMessageText);
         }
-
-        return runService.sendResponse(null, null, serviceRequest.getTenantId(), serviceRequest.getCallbackUri(), serviceResponse);
+        
+        return runService.sendResponse(null, authenticatedWho, serviceRequest.getTenantId(), serviceRequest.getCallbackUri(), serviceResponse);
     }
 
     public void sendMessageReplyResponse(ServiceRequest serviceRequest, String messageSid, String from, String to, String body) throws Exception {

--- a/src/main/java/com/manywho/services/twilio/services/MessageService.java
+++ b/src/main/java/com/manywho/services/twilio/services/MessageService.java
@@ -70,9 +70,10 @@ public class MessageService {
         cacheManager.saveMessageRequest(accountSid, from + to, serializedServiceRequest);
     }
 
-    public void storeAuthenticatedWho(String accountSid, String messageSid, AuthenticatedWho authenticatedWho) throws Exception {
+    public void storeAuthenticatedWho(String accountSid, String messageSid, String from, String to, AuthenticatedWho authenticatedWho) throws Exception {
         String serializedAuthenticatedWho = objectMapper.writeValueAsString(authenticatedWho);
         
         cacheManager.saveAuthenticatedWho(accountSid, messageSid, serializedAuthenticatedWho);
+        cacheManager.saveAuthenticatedWho(accountSid, from + to, serializedAuthenticatedWho);
     }
 }

--- a/src/main/java/com/manywho/services/twilio/services/MessageService.java
+++ b/src/main/java/com/manywho/services/twilio/services/MessageService.java
@@ -2,6 +2,7 @@ package com.manywho.services.twilio.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.manywho.sdk.entities.run.elements.config.ServiceRequest;
+import com.manywho.sdk.entities.security.AuthenticatedWho;
 import com.manywho.services.twilio.configuration.TwilioConfiguration;
 import com.manywho.services.twilio.factories.TwilioRestClientFactory;
 import com.manywho.services.twilio.managers.CacheManager;
@@ -67,5 +68,11 @@ public class MessageService {
         cacheManager.saveMessageRequest(accountSid, messageSid, serializedServiceRequest);
         // Store the request under the To number, as it's the only way to match an incoming message to a sent one
         cacheManager.saveMessageRequest(accountSid, from + to, serializedServiceRequest);
+    }
+
+    public void storeAuthenticatedWho(String accountSid, String messageSid, AuthenticatedWho authenticatedWho) throws Exception {
+        String serializedAuthenticatedWho = objectMapper.writeValueAsString(authenticatedWho);
+        
+        cacheManager.saveAuthenticatedWho(accountSid, messageSid, serializedAuthenticatedWho);
     }
 }

--- a/src/test/java/com/manywho/services/twilio/controllers/CallbackStatusTest.java
+++ b/src/test/java/com/manywho/services/twilio/controllers/CallbackStatusTest.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import static org.junit.Assert.assertEquals;
 import com.manywho.services.test.HttpClientForTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.manywho.sdk.entities.security.AuthenticatedWho;
 import com.manywho.services.test.FlowResponseMock;
 import com.manywho.services.test.TwilioServiceFunctionalTest;
 import com.manywho.services.twilio.managers.CacheManager;
@@ -52,7 +54,21 @@ public class CallbackStatusTest extends TwilioServiceFunctionalTest {
                 "mockAppSid",
                 "SMd931e01d8ce64158b8c962c6a1b24e5c"
         );
+        String redisKeyAuth =  String.format(
+                CacheManager.REDIS_KEY_WHO,
+                "mockAppSid",
+                "SMd931e01d8ce64158b8c962c6a1b24e5c"
+        );
+        
+        AuthenticatedWho authenticatedWho = new AuthenticatedWho();
+        authenticatedWho.setUsername("mockUser");
+        String mockAuthenticatedWho = new ObjectMapper().writeValueAsString(authenticatedWho);
 
+        mockJedis.set(
+                redisKeyAuth,
+                mockAuthenticatedWho
+        );
+        
         mockJedis.set(
                 redisKey,
                 getJsonFormatFileContent("CallbackStatusTest/callbackstatus1-redis.json")
@@ -146,6 +162,20 @@ public class CallbackStatusTest extends TwilioServiceFunctionalTest {
                 "mockAppSid",
                 "+44123456789+44123456788"
         );
+        String redisKeyAuth =  String.format(
+                CacheManager.REDIS_KEY_WHO,
+                "mockAppSid",
+                "+44123456789+44123456788"
+        );
+        
+        AuthenticatedWho authenticatedWho = new AuthenticatedWho();
+        authenticatedWho.setUsername("mockUser");
+        String mockAuthenticatedWho = new ObjectMapper().writeValueAsString(authenticatedWho);
+
+        mockJedis.set(
+                redisKeyAuth,
+                mockAuthenticatedWho
+        );
 
         mockJedis.set(
                 redisKey,
@@ -210,6 +240,20 @@ public class CallbackStatusTest extends TwilioServiceFunctionalTest {
                 "mockAppSid",
                 "+1123456789+1123456788"
         );
+        String redisKeyAuth =  String.format(
+                CacheManager.REDIS_KEY_WHO,
+                "mockAppSid",
+                "+1123456789+1123456788"
+        );
+        
+        AuthenticatedWho authenticatedWho = new AuthenticatedWho();
+        authenticatedWho.setUsername("mockUser");
+        String mockAuthenticatedWho = new ObjectMapper().writeValueAsString(authenticatedWho);
+
+        mockJedis.set(
+                redisKeyAuth,
+                mockAuthenticatedWho
+        );
 
         mockJedis.set(
                 redisKey,
@@ -241,7 +285,7 @@ public class CallbackStatusTest extends TwilioServiceFunctionalTest {
 
     private void checkHeaders(HttpClientForTest httpClientMock, Integer index) {
         // headers used to call the flow
-        assertEquals(null, httpClientMock.getExpectedRequestHeader(index, "Authorization").getValue());
+        assertEquals("ManyWhoTenantId%3Dnull%26ManyWhoUserId%3Dnull%26ManyWhoToken%3Dnull%26DirectoryId%3Dnull%26DirectoryName%3Dnull%26Email%3Dnull%26IdentityProvider%3Dnull%26TenantName%3Dnull%26Token%3Dnull%26Username%3DmockUser%26UserId%3Dnull%26FirstName%3Dnull%26LastName%3Dnull", httpClientMock.getExpectedRequestHeader(index, "Authorization").getValue());
         assertEquals("bbc6f524-c83a-11e6-9d9d-cec0c932ce01", httpClientMock.getExpectedRequestHeader(index, "ManyWhoTenant").getValue());
         assertEquals("gzip", httpClientMock.getExpectedRequestHeader(index, "accept-encoding").getValue());
         assertEquals("application/json", httpClientMock.getExpectedRequestHeader(index, "Content-Type").getValue());

--- a/src/test/java/com/manywho/services/twilio/controllers/SendMmsTest.java
+++ b/src/test/java/com/manywho/services/twilio/controllers/SendMmsTest.java
@@ -1,5 +1,6 @@
 package com.manywho.services.twilio.controllers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.manywho.sdk.utils.AuthorizationUtils;
 import com.manywho.services.test.TwilioServiceFunctionalTest;
 import com.twilio.sdk.resource.instance.Message;
@@ -70,6 +71,11 @@ public class SendMmsTest extends TwilioServiceFunctionalTest {
         assertJsonSame(
                 getJsonFormatFileContent("SendMmsTest/mms1-ok-request.json"),
                 mockJedis.get("service:twilio:requests:message:mockAppSid:44012345678900440123456788")
+        );
+        String authenticatedWhoJson = new ObjectMapper().writeValueAsString(getDefaultAuthenticatedWho()); 
+        assertJsonSame(
+                authenticatedWhoJson,
+                mockJedis.get("service:twilio:requests:who:mockAppSid:44012345678900440123456788")
         );
     }
 

--- a/src/test/java/com/manywho/services/twilio/controllers/SendSmsSimpleTest.java
+++ b/src/test/java/com/manywho/services/twilio/controllers/SendSmsSimpleTest.java
@@ -1,18 +1,24 @@
 package com.manywho.services.twilio.controllers;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
-import javax.ws.rs.core.*;
-import com.manywho.sdk.utils.AuthorizationUtils;
-import com.manywho.services.test.TwilioServiceFunctionalTest;
-import com.twilio.sdk.resource.instance.Message;
-import com.twilio.sdk.resource.instance.Sms;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.manywho.sdk.utils.AuthorizationUtils;
+import com.manywho.services.test.TwilioServiceFunctionalTest;
+import com.twilio.sdk.resource.instance.Message;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
@@ -68,6 +74,15 @@ public class SendSmsSimpleTest extends TwilioServiceFunctionalTest {
         assertJsonSame(
                 getJsonFormatFileContent("SendSmsSimpleTest/smssimple1-ok-request.json"),
                 mockJedis.get("service:twilio:requests:message:mockAppSid:44012345678900440123456788")
+        );
+        String authenticatedWhoJson = new ObjectMapper().writeValueAsString(getDefaultAuthenticatedWho()); 
+        assertJsonSame(
+                authenticatedWhoJson,
+                mockJedis.get("service:twilio:requests:who:mockAppSid:1")
+        );
+        assertJsonSame(
+                authenticatedWhoJson,
+                mockJedis.get("service:twilio:requests:who:mockAppSid:44012345678900440123456788")
         );
     }
 

--- a/src/test/java/com/manywho/services/twilio/controllers/SendSmsTest.java
+++ b/src/test/java/com/manywho/services/twilio/controllers/SendSmsTest.java
@@ -1,20 +1,24 @@
 package com.manywho.services.twilio.controllers;
 
-import com.manywho.sdk.utils.AuthorizationUtils;
-import com.manywho.services.test.TwilioServiceFunctionalTest;
-import com.twilio.sdk.resource.instance.Message;
-import com.twilio.sdk.resource.instance.Sms;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.manywho.sdk.utils.AuthorizationUtils;
+import com.manywho.services.test.TwilioServiceFunctionalTest;
+import com.twilio.sdk.resource.instance.Message;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
@@ -64,6 +68,11 @@ public class SendSmsTest extends TwilioServiceFunctionalTest {
         assertJsonSame(
                 getJsonFormatFileContent("SendSmsTest/sms1-ok-request.json"),
                 mockJedis.get("service:twilio:requests:message:mockAppSid:44012345678900440123456788")
+        );
+        String authenticatedWhoJson = new ObjectMapper().writeValueAsString(getDefaultAuthenticatedWho()); 
+        assertJsonSame(
+                authenticatedWhoJson,
+                mockJedis.get("service:twilio:requests:who:mockAppSid:44012345678900440123456788")
         );
     }
 


### PR DESCRIPTION
When a request to send an sms comes in, we now persist the auth token in the cache so that it can be sent to flow as part of the callback (e.g when Twilio calls back to the service the message was sent).